### PR TITLE
BUILD - Adjust output artifact to align with other library builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Upload libmodbus.so
       uses: actions/upload-artifact@v4
       with:
-        name: libmodbus${{ matrix.arch == 'aarch64-linux-musl' && '-64' || '' }}
+        name: libmodbus-${{ matrix.arch }}
         path: |
           /usr/${{ matrix.arch }}/lib/libmodbus.so*
           /usr/${{ matrix.arch }}/include/modbus*


### PR DESCRIPTION
This does not effect our build system in the slightest until we make the next release here and attach this artifact to the release

On release, in all repos that use "name: Download libmodbus library from release" we will need to change:

fileName: "libmodbus.zip"

to

fileName: "libmodbus-${{ matrix.arch }}.zip"

Repos that will need the change:
- cdu-build https://github.com/CoolITSystemsInc/cdu-build/blob/61dee87c25065ffedaf35ab645a4bf19804f737e/.github/workflows/main.yaml#L48
- dclc https://github.com/CoolITSystemsInc/dclc/blob/18f845534de6ddae0c8412d0aa504c9d52e34ff9/.github/workflows/build.yml#L66